### PR TITLE
Pull for upgrade of json_pure to modern version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+### 0.4.0 2011-11-01
+
+* Upgraded to json_pure ~> 1.6.1
+
+
 ### 0.3.0 / 2010-07-01
 
 * Upgraded to mechanize ~> 1.0.0.

--- a/gemspec.yml
+++ b/gemspec.yml
@@ -10,7 +10,7 @@ homepage: http://github.com/postmodern/gscraper
 has_yard: true
 
 dependencies:
-  json_pure: ~> 1.4.0
+  json_pure: ~> 1.6.1
   uri-query_params: ~> 0.5.0
   mechanize: ~> 1.0.0
 


### PR DESCRIPTION
Updated json_pure to 1.6.1 for more modern environments. 
